### PR TITLE
逆再生用のAudioContext生成のタイミングを修正。

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -61,4 +61,4 @@
 
 
 ## Caution
-This app is made for [wswsan](https://github.com/wswsans)'s private reason. So the user interface is rough and there are few descriptions. Sorry!
+This app is made for [wswsan](https://github.com/wswsans)'s private purpose. So the user interface is rough and there are few descriptions. Sorry!

--- a/scriptV1.js
+++ b/scriptV1.js
@@ -27,7 +27,7 @@ let analyser = null;
 let prevSpec = 0;
 let lipSyncInterval = null;
 // 逆再生
-let rev_context = new AudioContext();
+let rev_context = null;
 let rev_source = null;
 let gainNode = null;
 let Mbuffers = [];
@@ -74,7 +74,6 @@ const MReverser = (ct, start_time) => { // start_time: 逆再生ver
 	rev_started = false;
 	if (rev_source) rev_source.onended();
 	if (paused || !started || resetting) return;
-	rev_context = new AudioContext();
 	timeLog = 0;
 	rev_source = rev_context.createBufferSource();
 	rev_source.buffer = Mbuffers[ct];
@@ -135,6 +134,7 @@ const start = (ct) => {
 	};
 	// 逆再生用
 	$("button#MReverse").addClass("btn_on").click();
+	if (!rev_context) rev_context = new AudioContext();
 	if (!Mbuffers[ct]) {
 		const fReader = new FileReader();
 		fReader.readAsArrayBuffer(data[ct]);


### PR DESCRIPTION
ユーザの操作なしに`AudioContext`を生成してはいけない( https://developer.chrome.com/blog/autoplay/#web-audio )らしいので、30行目を修正。
また、逆再生の度に`AudioContext`を生成していたのを、最初に一度だけ生成するように修正。
